### PR TITLE
Simpler route generic

### DIFF
--- a/src/matrix/matrix-route-pattern.ts
+++ b/src/matrix/matrix-route-pattern.ts
@@ -13,7 +13,7 @@ import { rmatchMatrixAttr } from './rmatch-matrix-attr';
 /**
  * @internal
  */
-function addMatrixEntryMatchers(pattern: string, matchers: RouteMatcher<MatrixRoute.Entry, MatrixRoute>[]): void {
+function addMatrixEntryMatchers(pattern: string, matchers: RouteMatcher<MatrixRoute>[]): void {
 
   const parts = pattern.split(';');
 
@@ -42,6 +42,6 @@ function addMatrixEntryMatchers(pattern: string, matchers: RouteMatcher<MatrixRo
  *
  * @param pattern
  */
-export function matrixRoutePattern(pattern: string): RoutePattern<MatrixRoute.Entry, MatrixRoute> {
+export function matrixRoutePattern(pattern: string): RoutePattern<MatrixRoute> {
   return parseURLRoutePattern(pattern, addMatrixEntryMatchers);
 }

--- a/src/matrix/matrix-route.ts
+++ b/src/matrix/matrix-route.ts
@@ -10,7 +10,14 @@ import { parseURLRoute } from '../url/url-route.impl';
 /**
  * A route representing [matrix URL](https://www.w3.org/DesignIssues/MatrixURIs.html).
  */
-export type MatrixRoute<TEntry extends MatrixRoute.Entry = MatrixRoute.Entry> = URLRoute<TEntry>;
+export interface MatrixRoute extends URLRoute {
+
+  /**
+   * A path split onto matrix entries.
+   */
+  readonly path: readonly MatrixRoute.Entry[];
+
+}
 
 export namespace MatrixRoute {
 

--- a/src/matrix/matrix-route.ts
+++ b/src/matrix/matrix-route.ts
@@ -2,7 +2,7 @@
  * @packageDocumentation
  * @module @hatsy/route-match
  */
-import type { PathRoute } from '../path';
+import type { PathEntry } from '../path';
 import type { URLRoute } from '../url';
 import { decodeURLComponent } from '../url/decode-url.impl';
 import { parseURLRoute } from '../url/url-route.impl';
@@ -15,32 +15,28 @@ export interface MatrixRoute extends URLRoute {
   /**
    * A path split onto matrix entries.
    */
-  readonly path: readonly MatrixRoute.Entry[];
+  readonly path: readonly MatrixEntry[];
 
 }
 
-export namespace MatrixRoute {
+/**
+ * Matrix route entry.
+ *
+ * Extends file or directory with matrix attributes.
+ */
+export interface MatrixEntry extends PathEntry {
 
   /**
-   * Matrix route entry.
-   *
-   * Extends file or directory with matrix attributes.
+   * Matrix attributes represented by URL search parameters.
    */
-  export interface Entry extends PathRoute.Entry {
-
-    /**
-     * Matrix attributes represented by URL search parameters.
-     */
-    readonly attrs: URLSearchParams;
-
-  }
+  readonly attrs: URLSearchParams;
 
 }
 
 /**
  * @internal
  */
-function matrixRouteEntry(string: string): MatrixRoute.Entry {
+function matrixEntry(string: string): MatrixEntry {
 
   const parts = string.split(';');
   const attrs = new URLSearchParams();
@@ -63,5 +59,5 @@ function matrixRouteEntry(string: string): MatrixRoute.Entry {
  * @returns New matrix route instance.
  */
 export function matrixRoute(url: URL): MatrixRoute {
-  return parseURLRoute(url, matrixRouteEntry);
+  return parseURLRoute(url, matrixEntry);
 }

--- a/src/matrix/rmatch-matrix-attr.ts
+++ b/src/matrix/rmatch-matrix-attr.ts
@@ -13,7 +13,7 @@ import type { MatrixRoute } from './matrix-route';
  *
  * @returns New URL route matcher.
  */
-export function rmatchMatrixAttr(name: string, value?: string): RouteMatcher<MatrixRoute.Entry, MatrixRoute> {
+export function rmatchMatrixAttr(name: string, value?: string): RouteMatcher<MatrixRoute> {
 
   const condition: (attrs: URLSearchParams) => boolean = value == null
       ? attrs => attrs.has(name)

--- a/src/path/path-route.ts
+++ b/src/path/path-route.ts
@@ -4,15 +4,13 @@
  */
 /**
  * A route representing a path to file or directory.
- *
- * @typeparam TEntry  A type of route entries.
  */
-export interface PathRoute<TEntry extends PathRoute.Entry = PathRoute.Entry> {
+export interface PathRoute {
 
   /**
    * A path split onto file and directory entries.
    */
-  readonly path: readonly TEntry[];
+  readonly path: readonly PathRoute.Entry[];
 
   /**
    * Whether this is a route to directory.

--- a/src/path/path-route.ts
+++ b/src/path/path-route.ts
@@ -10,7 +10,7 @@ export interface PathRoute {
   /**
    * A path split onto file and directory entries.
    */
-  readonly path: readonly PathRoute.Entry[];
+  readonly path: readonly PathEntry[];
 
   /**
    * Whether this is a route to directory.
@@ -26,20 +26,16 @@ export interface PathRoute {
 
 }
 
-export namespace PathRoute {
+/**
+ * Path entry.
+ *
+ * Represents either file or directory.
+ */
+export interface PathEntry {
 
   /**
-   * Route entry.
-   *
-   * Represents either file or directory.
+   * Target file or directory name.
    */
-  export interface Entry {
-
-    /**
-     * Target file or directory name.
-     */
-    readonly name: string;
-
-  }
+  readonly name: string;
 
 }

--- a/src/route-captor.ts
+++ b/src/route-captor.ts
@@ -14,13 +14,9 @@ import type { RouteMatcher } from './route-matcher';
  * This function parameters depend on the kind of the capture reported by corresponding matcher.
  * The {@link RouteCaptorSignatureMap} maps capture kinds to their callback signatures.
  *
- * @typeparam TEntry  A type of matching route entries.
  * @typeparam TRoute  A type of matching route.
  */
-export type RouteCaptor<
-    TEntry extends PathRoute.Entry = PathRoute.Entry,
-    TRoute extends PathRoute<TEntry> = PathRoute<TEntry>,
-    > =
+export type RouteCaptor<TRoute extends PathRoute = PathRoute> =
 /**
  * @typeparam TKind  A type of the capture kind. Corresponds to method names of {@link RouteCaptorSignatureMap}.
  *
@@ -32,7 +28,7 @@ export type RouteCaptor<
         this: void,
         kind: TKind,
         key: string | number,
-        ...capture: Parameters<RouteCaptorSignatureMap<TEntry, TRoute>[TKind]>
+        ...capture: Parameters<RouteCaptorSignatureMap<TRoute>[TKind]>
     ) => void;
 
 /**
@@ -40,13 +36,9 @@ export type RouteCaptor<
  *
  * Each method name corresponds to capture kind, while its signature represents the capture itself.
  *
- * @typeparam TEntry  A type of matching route entries.
  * @typeparam TRoute  A type of matching route.
  */
-export interface RouteCaptorSignatureMap<
-    TEntry extends PathRoute.Entry = PathRoute.Entry,
-    TRoute extends PathRoute<TEntry> = PathRoute<TEntry>,
-    > {
+export interface RouteCaptorSignatureMap<TRoute extends PathRoute = PathRoute> {
 
   /**
    * Arbitrary route capture.
@@ -56,7 +48,7 @@ export interface RouteCaptorSignatureMap<
    * @param value  The captured string value.
    * @param context  A context of the capturing matcher.
    */
-  capture(value: string, context: RouteMatcher.Context<TEntry, TRoute>): void;
+  capture(value: string, context: RouteMatcher.Context<TRoute>): void;
 
   /**
    * Directories capture.
@@ -67,7 +59,7 @@ export interface RouteCaptorSignatureMap<
    * The first captured entry is in {@link RouteMatcher.Context.entryIndex `context`}.
    * @param context  A context of the capturing matcher.
    */
-  dirs(upto: number, context: RouteMatcher.Context<TEntry, TRoute>): void;
+  dirs(upto: number, context: RouteMatcher.Context<TRoute>): void;
 
   /**
    * Regular expression capture.
@@ -79,6 +71,6 @@ export interface RouteCaptorSignatureMap<
    * @param match  The regexp match array returned from `RegExp.prototype.exec()` method call.
    * @param context  A context of the capturing matcher.
    */
-  regexp(match: RegExpExecArray, context: RouteMatcher.Context<TEntry, TRoute>): void;
+  regexp(match: RegExpExecArray, context: RouteMatcher.Context<TRoute>): void;
 
 }

--- a/src/route-match.ts
+++ b/src/route-match.ts
@@ -11,19 +11,15 @@ import type { RouteMatcher } from './route-matcher';
  *
  * This is a function that reports registered partial matches via {@link RouteCaptor route capture receiver}.
  *
- * @typeparam TEntry  A type of matching route entries.
  * @typeparam TRoute  A type of matching route.
  */
-export type RouteMatch<
-    TEntry extends PathRoute.Entry = PathRoute.Entry,
-    TRoute extends PathRoute<TEntry> = PathRoute<TEntry>,
-    > =
+export type RouteMatch<TRoute extends PathRoute = PathRoute> =
 /**
  * @param capture  A {@link RouteCaptor route capture receiver} function to report partial matches to.
  */
     (
         this: void,
-        captor: RouteCaptor<TEntry, TRoute>,
+        captor: RouteCaptor<TRoute>,
     ) => void;
 
 /**
@@ -31,13 +27,9 @@ export type RouteMatch<
  *
  * This is an array of {@link RouteMatch matchers}.
  *
- * @typeparam TEntry  A type of supported route entries.
  * @typeparam TRoute  A type of supported route.
  */
-export type RoutePattern<
-    TEntry extends PathRoute.Entry = PathRoute.Entry,
-    TRoute extends PathRoute<TEntry> = PathRoute<TEntry>,
-    > = readonly RouteMatcher<TEntry, TRoute>[];
+export type RoutePattern<TRoute extends PathRoute = PathRoute> = readonly RouteMatcher<TRoute>[];
 
 export namespace RouteMatch {
 
@@ -77,21 +69,22 @@ export namespace RouteMatch {
  * Tries to match fragments of the given route by each of the pattern matchers, in order. If some matcher fails, the
  * match fails too. If all matchers succeed, the match result is constructed and returned.
  *
+ * @typeparam TRoute  A type of route to match against.
  * @param route  Target route to match against.
  * @param pattern  A pattern to match.
  * @param options  Route match options.
  *
  * @returns  Either successful route match object, or `null` if the route does not match the given pattern.
  */
-export function routeMatch<TEntry extends PathRoute.Entry, TRoute extends PathRoute<TEntry>>(
+export function routeMatch<TRoute extends PathRoute>(
     this: void,
     route: TRoute,
-    pattern: RoutePattern<TEntry, TRoute>,
+    pattern: RoutePattern<TRoute>,
     options: RouteMatch.Options = {},
-): RouteMatch<TEntry, TRoute> | null {
+): RouteMatch<TRoute> | null {
 
   const { path } = route;
-  let successfulMatch: RouteMatch<TEntry, TRoute> = () => {/* nothing captured */};
+  let successfulMatch: RouteMatch<TRoute> = () => {/* nothing captured */};
   let { fromEntry: entryIndex = 0, nameOffset = 0, fromMatcher: matcherIndex = 0 } = options;
 
   while (entryIndex < path.length) {

--- a/src/route-matcher.ts
+++ b/src/route-matcher.ts
@@ -8,13 +8,9 @@ import type { RouteMatch, RoutePattern } from './route-match';
 /**
  * Route fragment matcher.
  *
- * @typeparam TEntry  A type of supported route entries.
  * @typeparam TRoute  A type of supported route.
  */
-export interface RouteMatcher<
-    TEntry extends PathRoute.Entry = PathRoute.Entry,
-    TRoute extends PathRoute<TEntry> = PathRoute<TEntry>,
-    > {
+export interface RouteMatcher<TRoute extends PathRoute = PathRoute> {
 
   /**
    * Tests whether a fragment of the route satisfying this matcher's conditions.
@@ -25,8 +21,8 @@ export interface RouteMatcher<
    * or `false`/`null`/`undefined` otherwise.
    */
   test(
-      context: RouteMatcher.Context<TEntry, TRoute>,
-  ): RouteMatcher.Match<TEntry, TRoute> | false | null | undefined;
+      context: RouteMatcher.Context<TRoute>,
+  ): RouteMatcher.Match<TRoute> | false | null | undefined;
 
   /**
    * Searches for the fragment of the route satisfying this matcher's conditions.
@@ -43,7 +39,7 @@ export interface RouteMatcher<
    * not found.
    */
   find?(
-      context: RouteMatcher.Context<TEntry, TRoute>,
+      context: RouteMatcher.Context<TRoute>,
   ): readonly [RouteMatch, number] | false | null | undefined;
 
   /**
@@ -53,7 +49,7 @@ export interface RouteMatcher<
    *
    * @returns `true` if the route satisfies this matcher's condition, or `false` otherwise.
    */
-  tail?(context: RouteMatcher.TailContext<TEntry, TRoute>): boolean;
+  tail?(context: RouteMatcher.TailContext<TRoute>): boolean;
 
 }
 
@@ -64,10 +60,9 @@ export namespace RouteMatcher {
    *
    * May represent a position after the end of the route.
    *
-   * @typeparam TEntry  A type of tested route entries.
    * @typeparam TRoute  A type of tested route.
    */
-  export interface Position<TEntry extends PathRoute.Entry, TRoute extends PathRoute<TEntry>> {
+  export interface Position<TRoute extends PathRoute> {
 
     /**
      * Target route.
@@ -77,7 +72,7 @@ export namespace RouteMatcher {
     /**
      * The first entry of the match or `undefined` for the position after the route end.
      */
-    readonly entry?: TEntry;
+    readonly entry?: TRoute['path'][0];
 
     /**
      * The index of the {@link entry first entry} of the match.
@@ -94,7 +89,7 @@ export namespace RouteMatcher {
     /**
      * The route pattern the matcher belongs to.
      */
-    readonly pattern: RoutePattern<TEntry, TRoute>;
+    readonly pattern: RoutePattern<TRoute>;
 
     /**
      * The index of the matcher in the route pattern.
@@ -109,16 +104,14 @@ export namespace RouteMatcher {
    * This is passed to {@link RouteMatcher.test route matcher} to indicate the position inside the route the match
    * should be searched at.
    *
-   * @typeparam TEntry  A type of tested route entries.
    * @typeparam TRoute  A type of tested route.
    */
-  export interface Context<TEntry extends PathRoute.Entry, TRoute extends PathRoute<TEntry>>
-      extends Position<TEntry, TRoute> {
+  export interface Context<TRoute extends PathRoute> extends Position<TRoute> {
 
     /**
      * The first entry the matcher should match against.
      */
-    readonly entry: TEntry;
+    readonly entry: TRoute['path'][0];
 
     /**
      * The index of the {@link entry first entry} within the {@link route route path} the matcher should match against.
@@ -140,11 +133,9 @@ export namespace RouteMatcher {
    * This is passed to {@link RouteMatcher.tail tail route matcher} to indicate the position after the end of the route
    * the match should be applied to.
    *
-   * @typeparam TEntry  A type of tested route entries.
    * @typeparam TRoute  A type of tested route.
    */
-  export interface TailContext<TEntry extends PathRoute.Entry, TRoute extends PathRoute<TEntry>>
-      extends Position<TEntry, TRoute> {
+  export interface TailContext<TRoute extends PathRoute> extends Position<TRoute> {
 
     /**
      * `undefined` route entry indicating the position after the end of the route.
@@ -168,13 +159,9 @@ export namespace RouteMatcher {
    *
    * This is returned from {@link RouteMatch route matcher} and indicates the matching part of the route.
    *
-   * @typeparam TEntry  A type of matching route entries.
    * @typeparam TRoute  A type of matching route.
    */
-  export interface Match<
-      TEntry extends PathRoute.Entry = PathRoute.Entry,
-      TRoute extends PathRoute<TEntry> = PathRoute<TEntry>,
-      > {
+  export interface Match<TRoute extends PathRoute = PathRoute> {
 
     /**
      * The number of fully matching route entries.
@@ -210,7 +197,7 @@ export namespace RouteMatcher {
      *
      * It will be invoked by {@link RouteMatch successful route match} only.
      */
-    readonly callback?: RouteMatch<TEntry, TRoute>;
+    readonly callback?: RouteMatch<TRoute>;
 
   }
 

--- a/src/url/rmatch-search-param.ts
+++ b/src/url/rmatch-search-param.ts
@@ -2,7 +2,6 @@
  * @packageDocumentation
  * @module @hatsy/route-match
  */
-import type { PathRoute } from '../path';
 import type { RouteMatcher } from '../route-matcher';
 import type { URLRoute } from './url-route';
 
@@ -14,9 +13,9 @@ import type { URLRoute } from './url-route';
  *
  * @returns New URL route matcher.
  */
-export function rmatchSearchParam(name: string, value?: string): RouteMatcher<PathRoute.Entry, URLRoute> {
+export function rmatchSearchParam(name: string, value?: string): RouteMatcher<URLRoute> {
 
-  const condition: (position: RouteMatcher.Position<PathRoute.Entry, URLRoute>) => boolean = value == null
+  const condition: (position: RouteMatcher.Position<URLRoute>) => boolean = value == null
       ? ({ route: { url: { searchParams } } }) => searchParams.has(name)
       : ({ route: { url: { searchParams } } }) => searchParams.getAll(name).includes(value);
 

--- a/src/url/url-route-pattern.impl.ts
+++ b/src/url/url-route-pattern.impl.ts
@@ -1,5 +1,4 @@
 import { rmatchDirSep } from '../matchers';
-import type { PathRoute } from '../path';
 import type { RoutePattern } from '../route-match';
 import type { RouteMatcher } from '../route-matcher';
 import { rmatchSearchParam } from './rmatch-search-param';
@@ -8,15 +7,15 @@ import type { URLRoute } from './url-route';
 /**
  * @internal
  */
-export function parseURLRoutePattern<TEntry extends PathRoute.Entry, TRoute extends URLRoute<TEntry>>(
+export function parseURLRoutePattern<TRoute extends URLRoute>(
     pattern: string,
-    addEntryMatchers: (pattern: string, matchers: RouteMatcher<TEntry, TRoute>[]) => void,
-): RoutePattern<TEntry, TRoute> {
+    addEntryMatchers: (pattern: string, matchers: RouteMatcher<TRoute>[]) => void,
+): RoutePattern<TRoute> {
   if (!pattern) {
     return [];
   }
 
-  const matchers: RouteMatcher<TEntry, TRoute>[] = [];
+  const matchers: RouteMatcher<TRoute>[] = [];
   const [pathPattern, queryPattern] = pattern.split('?');
   const parts = pathPattern.split('/');
 

--- a/src/url/url-route-pattern.ts
+++ b/src/url/url-route-pattern.ts
@@ -2,7 +2,6 @@
  * @packageDocumentation
  * @module @hatsy/route-match
  */
-import type { PathRoute } from '../path';
 import { addPathEntryMatchers } from '../path/path-route-pattern.impl';
 import type { RoutePattern } from '../route-match';
 import type { URLRoute } from './url-route';
@@ -50,7 +49,7 @@ import { parseURLRoutePattern } from './url-route-pattern.impl';
  * @param pattern  Pattern string.
  * @returns Simple route pattern.
  */
-export function urlRoutePattern(pattern: string): RoutePattern<PathRoute.Entry, URLRoute> {
+export function urlRoutePattern(pattern: string): RoutePattern<URLRoute> {
   return parseURLRoutePattern(pattern, addPathEntryMatchers);
 }
 

--- a/src/url/url-route.impl.ts
+++ b/src/url/url-route.impl.ts
@@ -1,10 +1,10 @@
-import type { PathRoute } from '../path';
+import type { PathEntry } from '../path';
 import type { URLRoute } from './url-route';
 
 /**
  * @internal
  */
-export interface ParsedURLRoute<TEntry extends PathRoute.Entry> extends URLRoute {
+export interface ParsedURLRoute<TEntry extends PathEntry> extends URLRoute {
 
   readonly path: readonly TEntry[]
 
@@ -13,7 +13,7 @@ export interface ParsedURLRoute<TEntry extends PathRoute.Entry> extends URLRoute
 /**
  * @internal
  */
-export function parseURLRoute<TEntry extends PathRoute.Entry>(
+export function parseURLRoute<TEntry extends PathEntry>(
     url: URL,
     parseEntry: (name: string) => TEntry,
 ): ParsedURLRoute<TEntry> {

--- a/src/url/url-route.impl.ts
+++ b/src/url/url-route.impl.ts
@@ -4,10 +4,19 @@ import type { URLRoute } from './url-route';
 /**
  * @internal
  */
+export interface ParsedURLRoute<TEntry extends PathRoute.Entry> extends URLRoute {
+
+  readonly path: readonly TEntry[]
+
+}
+
+/**
+ * @internal
+ */
 export function parseURLRoute<TEntry extends PathRoute.Entry>(
     url: URL,
     parseEntry: (name: string) => TEntry,
-): URLRoute<TEntry> {
+): ParsedURLRoute<TEntry> {
 
   let { pathname } = url;
 

--- a/src/url/url-route.ts
+++ b/src/url/url-route.ts
@@ -9,7 +9,7 @@ import { parseURLRoute } from './url-route.impl';
 /**
  * A route representing an URL.
  */
-export interface URLRoute<TEntry extends PathRoute.Entry = PathRoute.Entry> extends PathRoute<TEntry> {
+export interface URLRoute extends PathRoute {
 
   /**
    * URL this route represents.

--- a/src/url/url-route.ts
+++ b/src/url/url-route.ts
@@ -2,7 +2,7 @@
  * @packageDocumentation
  * @module @hatsy/route-match
  */
-import type { PathRoute } from '../path';
+import type { PathEntry, PathRoute } from '../path';
 import { decodeURLComponent } from './decode-url.impl';
 import { parseURLRoute } from './url-route.impl';
 
@@ -30,7 +30,7 @@ export interface URLRoute extends PathRoute {
 /**
  * @internal
  */
-function urlRouteEntry(name: string): PathRoute.Entry {
+function urlEntry(name: string): PathEntry {
   return { name: decodeURLComponent(name) };
 }
 
@@ -42,5 +42,5 @@ function urlRouteEntry(name: string): PathRoute.Entry {
  * @returns New URL route instance.
  */
 export function urlRoute(url: URL): URLRoute {
-  return parseURLRoute(url, urlRouteEntry);
+  return parseURLRoute(url, urlEntry);
 }


### PR DESCRIPTION
- Generics depend on route type only
  Remove `TEntry` type parameters.
- Move route entry types to top level.
  Name them `PathEntry` and `MatrixEntry`

